### PR TITLE
Map "Approved" status to processing state

### DIFF
--- a/src/trade.js
+++ b/src/trade.js
@@ -64,12 +64,11 @@ class Trade extends Exchange.Trade {
           this._state = 'awaiting_reference_number';
         }
         break;
+      case 'Approved':
+        this._state = 'processing';
+        break;
       case 'Completed':
-        if (obj.transaction_hash) {
-          this._state = 'completed';
-        } else {
-          this._state = 'processing';
-        }
+        this._state = 'completed';
         break;
       default:
         this._state = 'awaiting_reference_number';


### PR DESCRIPTION
This is the status after a transaction has been approved, but not yet sent (so there's no tx id yet).