### PR TITLE
Set outAmount if given

### DIFF
--- a/src/trade.js
+++ b/src/trade.js
@@ -89,13 +89,18 @@ class Trade extends Exchange.Trade {
     this._inAmount = obj.inr;
     this._sendAmount = this._inAmount;
 
-    if (this._delegate.ticker) {
-      // TODO: use (historic) price from API once available
-      this._outAmount = Math.round(this._inAmount / this._delegate.ticker.buy.price * 100000000);
-      this._outAmountExpected = this._outAmount;
-    } else {
-      this._outAmount = null;
-      this._outAmountExpected = null;
+    this._outAmount = null;
+    this._outAmountExpected = null;
+
+    if (obj.btc && obj.btc !== '' && obj.btc !== '0') {
+      if (this.state !== 'completed') {
+        this._outAmountExpected = parseFloat(obj.btc) * 100000000.0;
+      } else {
+        this._outAmount = parseFloat(obj.btc) * 100000000.0;
+        this._outAmountExpected = this._outAmount;
+      }
+    } else if (this._delegate.ticker) {
+      this._outAmountExpected = Math.round(this._inAmount / this._delegate.ticker.buy.price * 100000000);
     }
   }
 


### PR DESCRIPTION
When the `btc` field is set on the trade object, we'll use it.

`outAmountExpected` is used when the trade is not yet `completed` and therefor the rate is not guaranteed. Perhaps the frontend can use ~ in that case. `outAmount` will be `null` in that case.

`outAmount` is only used when the trade is `completed`. It sets `outAmountExpected` to the same value.

The value returned by the API seems to be quite different from what our wallet calculates when placing the order...